### PR TITLE
yx: add `f.func` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project has no internal dependencies. The only external dependency is `pytho
 
 # Install
 
-Directly from this git repository with some of these branches:
+The installation is from this git repository under some of the following branches:
 1. `main`: the current stable version
 2. `dev`: some working in progress
 
@@ -29,12 +29,20 @@ pip install git+https://github.com/f-utils/f
 pip install git+https://github.com/f-utils/f/tree/dev
 ```
 
-With `uv`:
+With [uv](https://github.com/astral-sh/uv):
 ```bash
 # main branch
 uv add git+https://github.com/f-utils/f
 # dev branch
 uv add git+https://github.com/f-utils/f --branch dev
+```
+
+With [py](https://github.com/ximenesyuri/py):
+```bash
+# main branch
+py add f-utils/f --from github
+# dev branch 
+py add f-utils/f:dev --from github
 ```
 
 # Usage
@@ -44,6 +52,5 @@ See:
 - [ref](./doc/ref.md): with the reference manual
 
 See also:
-- [philosophy](https://github.com/f-utils/general/blob/main/docs/systematics.md)): with `f-utils` philosophy
-- [systematics](https://github.com/f-utils/general/blob/main/docs/systematics.md): with an exposition on the systematics
-
+- [philosophy](https://github.com/f-utils/general/blob/main/docs/philosophy.md)): with `f-utils` philosophy
+- [systematics](https://github.com/f-utils/general/blob/main/docs/systematics.md): with an exposition on `f-utils` systematics

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-`f` is the Python implementation of `f-utils` [systematics](https://github.com/f-utils/general/blob/main/docs/systematics.md) to ensure constructive type safety.
+`f` is the Python implementation of `f-utils` systematics to ensure constructive type safety by means of parametric polymorphisms.
 
 # Structure
 
@@ -20,6 +20,14 @@ The project has no internal dependencies. The only external dependency is `pytho
 The installation is from this git repository under some of the following branches:
 1. `main`: the current stable version
 2. `dev`: some working in progress
+
+With `git`:
+```bash
+# main branch
+git clone https://github.com/f-utils/f /path/to/your/venv/lib/python3/site-packages/f
+# dev branch
+git clone https://github.com/f-utils/f/tree/dev /path/to/your/venv/lib/python3/site-packages/f
+```
 
 With `pip`:
 ```bash
@@ -47,9 +55,15 @@ py add f-utils/f:dev --from github
 
 # Usage
 
-See:
-- [user](./doc/user.md): with the user manual
-- [ref](./doc/ref.md): with the reference manual
+Just import the class `f`:
+
+```python
+from f import f
+```
+
+For more details, see:
+- [user](./doc/user.md): user manual
+- [ref](./doc/ref.md): reference manual
 
 See also:
 - [philosophy](https://github.com/f-utils/general/blob/main/docs/philosophy.md)): with `f-utils` philosophy

--- a/f/__init__.py
+++ b/f/__init__.py
@@ -1,6 +1,3 @@
-import sys
-import os
-sys.path.append(os.path.dirname(__file__))
 from main import f
 
 f.t.db()

--- a/f/main.py
+++ b/f/main.py
@@ -44,13 +44,12 @@ class f:
             'all': ['a', 'any', 'every', 'all']
         }
 
-        def __init__(self, spec_name, at=None):
-            self.spec_name = spec_name
-            self.at = at
-
-        def __call__(self, *args, **kwargs):
-            func = self.mk(self.spec_name, self.at)
-            return func(*args, **kwargs)
+        def __new__(cls, spec_name, at=None):
+            specs_dict = at or cls.export()
+            if spec_name not in specs_dict:
+                raise ValueError(f"Function '{spec_name}' not found.")
+            func_obj = cls.mk(spec_name, specs_dict)
+            return func_obj
 
         @classmethod
         def _resolve_alias(cls, where):

--- a/f/main.py
+++ b/f/main.py
@@ -6,6 +6,26 @@ class f:
     _default_types = None
     _default_specs = None
 
+    class func:
+        class funcErr(Exception):
+            pass
+
+        def __init__(self, func):
+            if not callable(func):
+                raise self.funcErr(f"'{func}' is not a function.")
+            self._function = function
+
+        def __call__(self, *args, **kwargs):
+            return self._function(*args, **kwargs)
+
+        def __mul__(self, other):
+            if not isinstance(other, func):
+                raise self.funcErr(f"'{other}'is not a function: the composition is defined only between functions.")
+            def comp_(*args, **kwargs):
+                return self._function(other(*args, **kwargs))
+            return func(comp_)
+    f = func
+
     class spec:
         _aliases = {
             'metadata': {

--- a/f/main.py
+++ b/f/main.py
@@ -27,6 +27,9 @@ class f:
     f = func
 
     class spec:
+        class specErr(Exception):
+            pass
+
         _aliases = {
             'metadata': {
                 'description': ['d', 'desc', 'description'],
@@ -390,6 +393,9 @@ class f:
     s = spec
 
     class type:
+        class typeErr(Exception):
+            pass
+
         _aliases = {
             'description': ['d', 'desc', 'description'],
             'tags': ['t', 'tag', 'tags'],


### PR DESCRIPTION
# Description

1. Added class `f.func` whose objects are functions with special properties. For instance, for them `g*f` produces the compose function between `f` and `g`.
2. When one attach a function to a spectra, the attached function now is a special function (i.e, an object of `f.func`). To do that, methods `f.spec.__init__` and `f.spec.__call__` where replaced with `f.spec.__new__`. This makes more sense, since spectra are not supposed to be callable entities.
3. Added custom error classes for the classes `f.spec`, `f.type` and `f.func`.
4. Improved error messages in the class `f.spec`.

# Issues

1. https://github.com/f-utils/general/issues/26
2. https://github.com/f-utils/general/issues/25