### PR TITLE
feat: add type op class and f.conf method

### DIFF
--- a/f/main.py
+++ b/f/main.py
@@ -1,23 +1,25 @@
 from f.mods.type  import _type
+from f.mods.op    import _op
 from f.mods.spec  import _spec
 from f.mods.dspec import _dspec
 
 class f:
     _default_types = {}
+    _default_ops = {}
     _default_specs = {}
     _default_dspecs = {}
+    _allow_ops = False
 
     class err(Exception):
-        class ArgNumber(Exception):
-            pass
-        class ArgType(Exception):
-            pass
-        class NotFound(Exception):
-            pass
+        pass
 
     class type(metaclass=_type, at=_default_types):
         pass
     t = type
+
+    class op(metaclass=_op, at=_default_ops):
+        pass
+    o = op
 
     class spec(metaclass=_spec, at=_default_specs, att=_default_types):
         def __new__(cls, spec_name, at=None):
@@ -25,27 +27,62 @@ class f:
             def exec_func(*args, **kwargs):
                 spec = specs_dict[spec_name]
                 for arg_types, funcinfo in spec['spec']['body'].items():
+                    acceptable_types = f.acceptable_types_()
                     if not len(args) == len(arg_types):
-                        raise cls.f.ArgNumber(f"Expected '{len(arg_types)}' arguments. Received: '{len(args)}'.")
-                    if all(isinstance(arg, typ) for arg, typ in zip(args, arg_types)):
+                        raise f.err(f"Expected '{len(arg_types)}' arguments. Received: '{len(args)}'.")
+                    if all(isinstance(arg, typ) for arg, typ in zip(args, arg_types) if typ in acceptable_types):
                         return funcinfo['func'](*args, **kwargs)
                 mismatch_types = [type(arg).__name__ for arg in args if type(arg) not in arg_types]
                 if mismatch_types:
-                    raise f.err.ArgType(f"Types '{mismatch_types}' are not in the domain of spectrum '{spec_name}'.")
-                raise f.err.NotFound(f"Spectrum '{spec_name}' not found in database {at}.")
+                    raise f.err(f"Types '{mismatch_types}' are not in the domain of spectrum '{spec_name}'.")
+                raise f.err(f"Spectrum '{spec_name}' not found in database {at}.")
             return exec_func
     s = spec
 
     class dspec(metaclass=_dspec, at=_default_dspecs, att=_default_types):
         def __new__(cls, dspec_name, at=None):
             dspecs_dict = at if at is not None else f._default_dspecs
+
             def exec_func(*args, **kwargs):
                 dspec = dspecs_dict[dspec_name]
+                acceptable_types = f.acceptable_types_()
                 for arg_types, funcinfo in dspec['spec']['body'].items():
-                    if all(isinstance(arg, arg_types) or arg is None for arg in args):
+                    if all((isinstance(arg, arg_types) or arg is None) and (arg in acceptable_types or arg is None) for arg in args):
                         return funcinfo['func'](*args, **kwargs)
                 mismatch_args = [arg for arg in args if type(arg) not in arg_types]
                 mismatch_types = [type(arg).__name__ for arg in mismatch_args]
-                raise f.err.ArgType(f"Types '{mismatch_types}' for arguments '{mismatch_args}' are not allowed for dspec '{dspec_name}'.")
+                raise f.err(f"Types '{mismatch_types}' for arguments '{mismatch_args}' are not allowed for dspec '{dspec_name}'.")
             return exec_func
     ds = dspec
+
+    @classmethod
+    def conf(cls, allow_ops=False, allow_subtypes=False):
+        cls._allow_ops = allow_ops
+        cls._allow_subtypes = allow_subtypes
+    c = conf
+
+    @classmethod
+    def acceptable_types_(cls):
+        base_types = set(cls._default_types.keys())
+        if cls._allow_subtypes:
+            base_types.update({subtype for basetype in base_types for subtype in basetype.__subclasses__()})
+
+        if cls._allow_ops is False:
+            return base_types
+
+        allowed_ops = {}
+        if isinstance(cls._allow_ops, list):
+            allowed_ops = {op_name: op['op']['func'] for op_name, op in cls._default_ops.items() if op_name in cls._allow_ops}
+        elif cls._allow_ops is True:
+            allowed_ops = {op_name: op['op']['func'] for op_name, op in cls._default_ops.items()}
+
+        derived_types = set()
+        for op_func in allowed_ops.values():
+            for base_type in base_types:
+                try:
+                    new_type = op_func(base_type)
+                    if isinstance(new_type, type):
+                        derived_types.add(new_type)
+                except:
+                    continue
+        return base_types.union(derived_types)

--- a/f/mods/op.py
+++ b/f/mods/op.py
@@ -1,0 +1,78 @@
+from f.mods.meta import meta
+
+def type_checker_(func):
+    def wrapper(*args):
+        if not all(isinstance(arg, type) for arg in args):
+            raise meta.err(f"All arguments of '{func.__name__}' must be types.")
+        result = func(*args)
+        if not isinstance(result, type):
+            raise meta.err(f"The function '{func.__name__}' must return a type.")
+        return result
+    return wrapper
+
+class _op(type):
+    def __new__(mcs, name, bases, dct, **kwargs):
+        cls = super().__new__(mcs, name, bases, dct)
+        cls.at = kwargs.get('at', None)
+        return cls
+
+    def database(cls, *args):
+        return meta.database(cls.at, *args)
+    db = database
+
+    def init(cls, op_name, desc, func):
+        if not callable(func):
+            raise meta.err(f"The operation '{op_name}' must be a function or a lambda.")
+        checked_func_ = type_checker_(func)
+        cls.at[op_name] = {
+            'metadata': {
+                'desc': desc,
+                'tags': [],
+                'comments': {}
+            },
+            'op': {
+                'func': func,
+                'repr': meta.repr(func)
+            }
+        }
+    i = init
+
+    def add(cls, op_name, attribute):
+        aliases = {
+            'comments': ['c', 'comment'],
+            'tags': ['t', 'tag']
+        }
+        return meta.add(op_name, attribute, cls.at, aliases)
+    a = add
+
+    def delete(cls, op_name, attribute):
+        aliases = {
+            'comments': ['c', 'comment'],
+            'tags': ['t', 'tag']
+        }
+        return meta.delete(op_name, attribute, cls.at, aliases)
+    d = delete
+
+    def update(cls, op_name, attribute):
+        aliases = {
+            'desc': ['d', 'desc', 'description'],
+            'tags': ['t', 'tag', 'tags'],
+            'comments': ['c', 'comment', 'comments'],
+            'func': ['f', 'func', 'function', 'o', 'op']
+        }
+        attribute = meta.resolve(attribute, aliases)
+        if attribute == 'func':
+            def _update_func_(new_func):
+                if not callable(new_func):
+                    raise meta.err(f"The new function '{new_func.__name__}' must be callable.")
+                checked_func_ = type_checker_(new_func)
+                cls.at[op_name]['op']['func'] = new_func
+                cls.at[op_name]['op']['repr'] = meta.repr(new_func)
+            return _update_func_
+
+        return meta.update(op_name, attribute, cls.at, aliases)
+    u = update
+
+    def export(cls):
+        return meta.export(cls.at)
+    E = export


### PR DESCRIPTION
# Description

1. Add `f.o/op` class, which contains "accessible type operations".
2. Add method `f.conf` to be used to configure a `f` instance. Currently has two settings: `allow_ops` and `allow_subtypes`. 

If `allow_ops` is `True`, then one can extend a spectra or a dynamic spectra not only with the base types in `f._default_types`, but also with any returning type of any type operations in `f._default_ops`, applied to types in `f._default_types`.

If `allow_subtypes` is `True`, one can extend spec/dspec by subtypes of types in `f._default_types`.

In sum:
1. `allow_ops` controls whether accessible types are closed under provided type operations
2. `allow_subtypes` controls whether accessible types are closed under taking subtypes